### PR TITLE
prepare.sh: Install `wget` `unzip`

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -13,7 +13,7 @@ wget -O libs/cmake-3.14.0.tar.gz -c https://github.com/Kitware/CMake/releases/do
 }
 
 function prereq() {
-sudo apt-get install make pkg-config autoconf build-essential
+sudo apt-get update && sudo apt-get install -y make pkg-config autoconf build-essential wget unzip
 }
 
 function unpack() {


### PR DESCRIPTION
Issue: `wget` `unzip` not installed by default on `ubuntu:14.04` docker image (verified on [DIGEST:sha256:881afbae521c910f764f7187dbfbca3cc10c26f8bafa458c76dda009a901c29d](https://hub.docker.com/layers/library/ubuntu/14.04/images/sha256-881afbae521c910f764f7187dbfbca3cc10c26f8bafa458c76dda009a901c29d))

Solution: install `wget` `unzip` in `prereq` step